### PR TITLE
Adds support for multiple doors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [Homebridge](https://github.com/nfarina/homebridge) plug-in for iSmartGate HomeKit devices to expose their Temperature & Battery services, which would otherwise be hidden.
 
 ## Things to know
-* Supports only a single garage door / gate
+* Displays a single temperature value which is the average across the configured doors. Battery level is that of the sensor with the lowest level.
 * Only exposes the Temperature & Battery services, as the device already has HomeKit support for the Garage Door service. If you need a Garage Door service as well, take a look at the plug-in [homebridge-gogogate2](https://www.npmjs.com/package/homebridge-gogogate2).
-* Only the iSmartGate Gate Lite is supported. While no other devices have been tested, I see no reason that they should not work.
+* Only the iSmartGate Gate Pro and Lite are supported. While no other devices have been tested, I see no reason that they should not work.
 
 ### Legal
 * Licensed under [MIT](LICENSE)

--- a/config.schema.json
+++ b/config.schema.json
@@ -41,7 +41,17 @@
             "minLength": 1,
             "required": true
          },
-         "debug":{
+         "doors":{
+            "title":"Number of doors",
+            "type":"integer",
+            "format":"integer",
+            "placeholder": 1,
+            "description": "How many doors are configured on your iSmartGate",
+            "minimum": 1,
+            "maximum": 3,
+            "required": true
+         },
+        "debug":{
             "title":"Debug logging",
             "type":"boolean",
             "description":"Turns on additional logging (can be helpful for diagnosing issues)"
@@ -74,6 +84,16 @@
             {
                "key":"password",
                "type":"password"
+            }
+         ]
+      },
+      {
+         "type":"flex",
+         "flex-flow":"row wrap",
+         "items":[
+            {
+               "key":"doors",
+               "type":"integer"
             }
          ]
       },

--- a/index.js
+++ b/index.js
@@ -19,11 +19,11 @@ function iSmartGate(log, config) {
     this.hostname = config["hostname"];
     this.username = config["username"];
     this.password = config["password"];
-    this.doors = config["doors"]
+    this.doors = config["doors"];
     this.response = null;
     this.debug = config["debug"] || false;
 
-    this.currentDoor = 1
+    this.currentDoor = 1;
     this.CurrentTemperatures = [];
     this.AverageTemperature = null;
     this.BatteryLevel = 100;
@@ -145,7 +145,6 @@ iSmartGate.prototype = {
         this.TemperatureSensor
             .getCharacteristic(Characteristic.CurrentTemperature)
             .on('get', this._getValue.bind(this, "CurrentTemperature"));
-
 
         this.BatteryService = new Service.BatteryService(this.name);
         this.BatteryService

--- a/index.js
+++ b/index.js
@@ -19,11 +19,14 @@ function iSmartGate(log, config) {
     this.hostname = config["hostname"];
     this.username = config["username"];
     this.password = config["password"];
+    this.doors = config["doors"]
     this.response = null;
     this.debug = config["debug"] || false;
 
-    this.CurrentTemperature = null;
-    this.BatteryLevel = null;
+    this.currentDoor = 1
+    this.CurrentTemperatures = [];
+    this.AverageTemperature = null;
+    this.BatteryLevel = 100;
 
     // Log us in & start running the capture process
     try {this._login(true);}
@@ -37,77 +40,101 @@ iSmartGate.prototype = {
         callback();
     },
 
-	_login: function(firstLoad) {
-		request.post({
-			url: "http://" + this.hostname + "/index.php",
-			form: {
-				"login": this.username,
-				"pass": this.password,
-				"send-login": "Sign in"
-			},
-			jar: cookieJar
-		}, function(err, response, body) {
-			if (!err && response.statusCode == 200) {
-				this.log("Logged into iSmartGate");
+    _login: function(firstLoad) {
+        request.post({
+            url: "http://" + this.hostname + "/index.php",
+            form: {
+                "login": this.username,
+                "pass": this.password,
+                "sesion-abierta": 1,
+                "send-login": "Sign in"
+            },
+            jar: cookieJar
+        }, function(err, response, body) {
+            if (!err && response.statusCode == 200) {
+                this.log("Logged into iSmartGate");
 
-				// Save the login headers
-				this.response = response;
+                // Save the login headers
+                this.response = response;
 
-				// Get the data initially
-				this._refresh();
+                // Get the data initially
+                this._refresh();
 
-				// Refresh periodically (every minute)
-				if(firstLoad) {setInterval(function() {this._refresh();}.bind(this), 60000);}
-			}
-			else {this.log("Could not login.", err, response, body);}
-		}.bind(this));
-	},
+                // Refresh periodically (every minute)
+                if(firstLoad) {setInterval(function() {this._refresh();}.bind(this), 60000);}
+            }
+            else {this.log("Could not login.", err, response, body);}
+        }.bind(this));
+    },
 
     _refresh: function() {
-        if(this.debug) {this.log("Start refreshing temperature & battery");}
+        if(this.debug) {this.log("Start refreshing temperature & battery for door " + this.currentDoor);}
 
         request.get({
-            url: "http://" + this.hostname + "/isg/temperature.php?door=1",
+
+            url: "http://" + this.hostname + "/isg/temperature.php?door=" + this.currentDoor,
             header: this.response.headers,
             jar: cookieJar
         }, function(err, response, body) {
             if (!err && response.statusCode == 200) {
+                var index = this.currentDoor - 1;
+
                 try {body = JSON.parse(body);}
                 catch(err) {
-					if(body == "Restricted Access") {
-						this.log("Login token expired, refreshing...");
-						this._login();
-					}
-					else {this.log("Could not connect.", "Check http://" + this.hostname + " to make sure the device is still reachable & no captcha is showing.");}
-				}
+                    if(body == "Restricted Access") {
+                        this.log("Login token expired, refreshing...");
+                        this._login();
+                    }
+                    else {this.log("Could not connect.", "Check http://" + this.hostname + " to make sure the device is still reachable & no captcha is showing.");}
+                }
 
-                if(this.debug) {this.log("Succesfully obtained temperature.", body);}
+                if(this.debug) {this.log("Succesfully obtained temperature. for door " + this.currentDoor, body);}
 
-                // Find & set the CurrentTemperature
-                this.CurrentTemperature = body[0] / 1000;
-                this.TemperatureSensor.getCharacteristic(Characteristic.CurrentTemperature).updateValue(this.CurrentTemperature);
+                // Find & set the Average Temperature
+                this.CurrentTemperatures[index] = parseInt(body[0], 10);
+                var totalTempX1K = this.CurrentTemperatures.reduce((a, b) => a + b)
+                this.AverageTemperature = (totalTempX1K / this.CurrentTemperatures.length) / 1000
+
+                this.TemperatureSensor.getCharacteristic(Characteristic.CurrentTemperature).updateValue(this.AverageTemperature);
 
                 // Find the BatteryLevel
+                var batteryLevel = null;
                 switch (body[1]) {
-                    case "full":    this.BatteryLevel = 100;    break;
-                    case "80":      this.BatteryLevel = 80;     break;
-                    case "60":      this.BatteryLevel = 60;     break;
-                    case "40":      this.BatteryLevel = 40;     break;
-                    case "20":      this.BatteryLevel = 20;     break;
-                    case "low":     this.BatteryLevel = 10;     break;
+                    case "full":    batteryLevel = 100;    break;
+                    case "80":      batteryLevel = 80;     break;
+                    case "60":      batteryLevel = 60;     break;
+                    case "40":      batteryLevel = 40;     break;
+                    case "20":      batteryLevel = 20;     break;
+                    case "low":     batteryLevel = 10;     break;
 
                     default:
-                        this.log("Unexpected BatteryLevel detected.", body[1], body);
-                        this.BatteryLevel = 0;
+                        this.log("Unexpected BatteryLevel detected on door " + this.currentDoor, body[1], body);
+                        batteryLevel = 0;
                     break;
+                }
+                if (this.debug) {this.log("BatteryLevel on door " + this.currentDoor + ": ", body[1], body);}
+                if (batteryLevel < this.BatteryLevel) {
+                    this.BatteryLevel = batteryLevel
                 }
 
                 // Set the Status Low Battery
-                if(this.BatteryLevel <= 10) {this.BatteryService.setCharacteristic(Characteristic.StatusLowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);}
-                else {this.BatteryService.setCharacteristic(Characteristic.StatusLowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);}
+                if(this.BatteryLevel <= 10) {
+                    this.log("Battery level on door " + this.currentDoor + " is low.")
+                    this.BatteryService.setCharacteristic(Characteristic.StatusLowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+                }
+                else {
+                    this.BatteryService.setCharacteristic(Characteristic.StatusLowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+                }
 
                 // Set the Battery Level
                 this.BatteryService.setCharacteristic(Characteristic.BatteryLevel, this.BatteryLevel);
+
+                if (this.currentDoor == this.doors) {
+                    this.currentDoor = 1;
+                } else {
+                    this.currentDoor += 1;
+                }
+
             }
             else {this.log("Could not connect.", err, response, body);}
         }.bind(this));
@@ -119,11 +146,11 @@ iSmartGate.prototype = {
             .getCharacteristic(Characteristic.CurrentTemperature)
             .on('get', this._getValue.bind(this, "CurrentTemperature"));
 
+
         this.BatteryService = new Service.BatteryService(this.name);
         this.BatteryService
             .getCharacteristic(Characteristic.BatteryLevel)
             .on('get', this._getValue.bind(this, "BatteryLevel"));
-
         this.TemperatureSensor.addLinkedService(this.BatteryService);
 
         this.informationService = new Service.AccessoryInformation();
@@ -146,7 +173,7 @@ iSmartGate.prototype = {
 
         switch (CharacteristicName) {
 
-            case "CurrentTemperature":  callback(null, this.CurrentTemperature);    break;
+            case "CurrentTemperature":  callback(null, this.AverageTemperature);    break;
             case "BatteryLevel":        callback(null, this.BatteryLevel);          break;
 
             default:

--- a/index.js
+++ b/index.js
@@ -113,13 +113,14 @@ iSmartGate.prototype = {
                     break;
                 }
                 if (this.debug) {this.log("BatteryLevel on door " + this.currentDoor + ": ", body[1], body);}
+                if (batteryLevel <= 10) {this.log("Battery level on door " + this.currentDoor + " is low.");}
+
                 if (batteryLevel < this.BatteryLevel) {
                     this.BatteryLevel = batteryLevel
                 }
 
                 // Set the Status Low Battery
                 if(this.BatteryLevel <= 10) {
-                    this.log("Battery level on door " + this.currentDoor + " is low.")
                     this.BatteryService.setCharacteristic(Characteristic.StatusLowBattery, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
                 }
                 else {


### PR DESCRIPTION
Made a small tweak that allows configuring the number of doors that are connected to the iSmartGate.  On each refresh the plugin will retrieve values for a different door.

Temperature displayed is the average across the sensors. 
Battery level displayed is the lowest among the sensors. 

I tested this against my iSmartGate Pro with 2 doors.